### PR TITLE
V0.1.2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,3 @@
-#### 0.1.1 November 12 2018 ####
-Made the Petabridge.Tracing.ApplicationInsights strong-named using [Public Signing](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/public-signing.md#public-signing)
-
-#### 0.1.0 September 21 2018 ####
-Initial release of Petabridge.Tracing.ApplicationInsights.
-
-We built this driver in order to provide a layer of [OpenTracing](http://opentracing.io/) compatibility on top of [Microsoft's Application Insights](https://azure.microsoft.com/en-us/services/application-insights/) telemetry and analytics service.
-
-This driver follows [the Application Insights to OpenTracing conventions](https://docs.microsoft.com/en-us/azure/application-insights/application-insights-correlation#open-tracing-and-application-insights) outlined by the Application Insights team.
-
-`Petabridge.Tracing.ApplicationInsights` is professionally maintained and tested by [Petabridge](http://petabridge.com/) and is used inside some of our commercial products, such as [Phobos: Enterprise Akka.NET DevOps](https://phobos.petabridge.com/).
+#### 0.1.2 November 18 2019 ####
+* [Resolved: case insensitive HTTP headers](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/22)
+* Updated all underlying dependencies.

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -9,6 +9,7 @@ trigger:
   branches:
     include:
       - refs/tags/*
+      
 pr: none
 
 variables:

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2018 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.1.1</VersionPrefix>
-    <PackageReleaseNotes>Made the Petabridge.Tracing.ApplicationInsights strong-named using [Public Signing](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/public-signing.md#public-signing)</PackageReleaseNotes>
+    <VersionPrefix>0.1.2</VersionPrefix>
+    <PackageReleaseNotes>[Resolved: case insensitive HTTP headers](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/22)
+Updated all underlying dependencies.</PackageReleaseNotes>
     <PackageIconUrl>
     </PackageIconUrl>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>


### PR DESCRIPTION
#### 0.1.2 November 18 2019 ####
* [Resolved: case insensitive HTTP headers](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/22)
* Updated all underlying dependencies.