### PR TITLE
Added v0.2.1 Release Notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
-#### 0.2.0 April 14 2020 ####
-* Updated to latest Application Insights driver (2.13.1)
-* Updated to latest Akka.NET version (1.4.4)
+#### 0.2.1 November 12 2020 ####
+* Updated to latest Application Insights driver (2.16.0)
+* Updated to latest [Akka.NET version (1.4.11)](https://github.com/akkadotnet/akka.net/releases/tag/1.4.11)
+* [Added constructor overload for passing in `IScopeManager` more easily](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/64)

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,10 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2020 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.1.3</VersionPrefix>
-    <PackageReleaseNotes>Updated to latest Application Insights driver (2.12.1)
-Updated to latest Akka.NET version (1.3.17)</PackageReleaseNotes>
+    <VersionPrefix>0.2.1</VersionPrefix>
+    <PackageReleaseNotes>Updated to latest Application Insights driver (2.16.0)
+Updated to latest [Akka.NET version (1.4.11)](https://github.com/akkadotnet/akka.net/releases/tag/1.4.11)
+[Added constructor overload for passing in `IScopeManager` more easily](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/64)</PackageReleaseNotes>
     <PackageIconUrl>
     </PackageIconUrl>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>


### PR DESCRIPTION
#### 0.2.1 November 12 2020 ####
* Updated to latest Application Insights driver (2.16.0)
* Updated to latest [Akka.NET version (1.4.11)](https://github.com/akkadotnet/akka.net/releases/tag/1.4.11)
* [Added constructor overload for passing in `IScopeManager` more easily](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/64)