### PR TITLE
propagate traced errors to App Insights

### DIFF
--- a/src/Petabridge.Tracing.ApplicationInsights/DependencySpan.cs
+++ b/src/Petabridge.Tracing.ApplicationInsights/DependencySpan.cs
@@ -38,7 +38,15 @@ namespace Petabridge.Tracing.ApplicationInsights
         public override ISpan SetTag(string key, string value)
         {
             // guard the trace so we don't collect garbage
-            if (!Finished.HasValue) _operation.Telemetry.Properties[key] = value;
+            if (!Finished.HasValue)
+            {
+                _operation.Telemetry.Properties[key] = value;
+                // need to flag this as an error in Application Insights
+                if (key.Equals(OpenTracing.Tag.Tags.Error.Key))
+                {
+                    _operation.Telemetry.Success = false;
+                }
+            }
 
             return this;
         }

--- a/src/Petabridge.Tracing.ApplicationInsights/RequestSpan.cs
+++ b/src/Petabridge.Tracing.ApplicationInsights/RequestSpan.cs
@@ -37,7 +37,16 @@ namespace Petabridge.Tracing.ApplicationInsights
         public override ISpan SetTag(string key, string value)
         {
             // guard the trace so we don't collect garbage
-            if (!Finished.HasValue) _operation.Telemetry.Properties[key] = value;
+            if (!Finished.HasValue)
+            {
+                _operation.Telemetry.Properties[key] = value;
+                
+                // need to flag this as an error in Application Insights
+                if (key.Equals(OpenTracing.Tag.Tags.Error.Key))
+                {
+                    _operation.Telemetry.Success = false;
+                }
+            }
 
             return this;
         }


### PR DESCRIPTION
When a `OpenTracing.Tag.Tags.Error` is added to any `ISpan` instances, mark the request as not successful in Application Insights.