### PR TITLE
v0.3.0 Release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: Akka
+    versions:
+    - 1.4.16
+    - 1.4.17
+  - dependency-name: Microsoft.NET.Test.Sdk
+    versions:
+    - 16.8.3
+    - 16.9.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,3 @@
-#### 0.2.1 November 12 2020 ####
-* Updated to latest Application Insights driver (2.16.0)
-* Updated to latest [Akka.NET version (1.4.11)](https://github.com/akkadotnet/akka.net/releases/tag/1.4.11)
-* [Added constructor overload for passing in `IScopeManager` more easily](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/64)
+#### 0.3.0 March 18 2022 ####
+* Updated to latest Application Insights driver (2.20.0)
+* [Resolved: Need to mark errors recorded in spans as errors in the Application Insights client](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/114)

--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -21,13 +21,13 @@ jobs:
     parameters:
       name: 'windows_pr'
       displayName: 'Windows PR Validation'
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
       scriptFileName: build.cmd
       scriptArgs: all
   - template: azure-pipeline.template.yaml
     parameters:
       name: 'linux_pr'
       displayName: 'Linux PR Validation'
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-latest'
       scriptFileName: ./build.sh
       scriptArgs: all

--- a/src/Petabridge.Tracing.ApplicationInsights.Demo/Petabridge.Tracing.ApplicationInsights.Demo.csproj
+++ b/src/Petabridge.Tracing.ApplicationInsights.Demo/Petabridge.Tracing.ApplicationInsights.Demo.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.25" />
+    <PackageReference Include="Akka" Version="1.4.26" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Petabridge.Tracing.ApplicationInsights.Demo/Petabridge.Tracing.ApplicationInsights.Demo.csproj
+++ b/src/Petabridge.Tracing.ApplicationInsights.Demo/Petabridge.Tracing.ApplicationInsights.Demo.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.26" />
+    <PackageReference Include="Akka" Version="1.4.27" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Petabridge.Tracing.ApplicationInsights.Demo/Petabridge.Tracing.ApplicationInsights.Demo.csproj
+++ b/src/Petabridge.Tracing.ApplicationInsights.Demo/Petabridge.Tracing.ApplicationInsights.Demo.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.11" />
+    <PackageReference Include="Akka" Version="1.4.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Petabridge.Tracing.ApplicationInsights.Demo/Petabridge.Tracing.ApplicationInsights.Demo.csproj
+++ b/src/Petabridge.Tracing.ApplicationInsights.Demo/Petabridge.Tracing.ApplicationInsights.Demo.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.18" />
+    <PackageReference Include="Akka" Version="1.4.25" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Petabridge.Tracing.ApplicationInsights.Demo/Petabridge.Tracing.ApplicationInsights.Demo.csproj
+++ b/src/Petabridge.Tracing.ApplicationInsights.Demo/Petabridge.Tracing.ApplicationInsights.Demo.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.27" />
+    <PackageReference Include="Akka" Version="1.4.35" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Petabridge.Tracing.ApplicationInsights.Tests/Petabridge.Tracing.ApplicationInsights.Tests.csproj
+++ b/src/Petabridge.Tracing.ApplicationInsights.Tests/Petabridge.Tracing.ApplicationInsights.Tests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/src/Petabridge.Tracing.ApplicationInsights.Tests/Petabridge.Tracing.ApplicationInsights.Tests.csproj
+++ b/src/Petabridge.Tracing.ApplicationInsights.Tests/Petabridge.Tracing.ApplicationInsights.Tests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />

--- a/src/Petabridge.Tracing.ApplicationInsights/DependencySpan.cs
+++ b/src/Petabridge.Tracing.ApplicationInsights/DependencySpan.cs
@@ -38,7 +38,15 @@ namespace Petabridge.Tracing.ApplicationInsights
         public override ISpan SetTag(string key, string value)
         {
             // guard the trace so we don't collect garbage
-            if (!Finished.HasValue) _operation.Telemetry.Properties[key] = value;
+            if (!Finished.HasValue)
+            {
+                _operation.Telemetry.Properties[key] = value;
+                // need to flag this as an error in Application Insights
+                if (key.Equals(OpenTracing.Tag.Tags.Error.Key))
+                {
+                    _operation.Telemetry.Success = false;
+                }
+            }
 
             return this;
         }

--- a/src/Petabridge.Tracing.ApplicationInsights/Petabridge.Tracing.ApplicationInsights.csproj
+++ b/src/Petabridge.Tracing.ApplicationInsights/Petabridge.Tracing.ApplicationInsights.csproj
@@ -13,7 +13,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.16.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
   </ItemGroup>
 

--- a/src/Petabridge.Tracing.ApplicationInsights/Petabridge.Tracing.ApplicationInsights.csproj
+++ b/src/Petabridge.Tracing.ApplicationInsights/Petabridge.Tracing.ApplicationInsights.csproj
@@ -13,7 +13,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />
   </ItemGroup>
 

--- a/src/Petabridge.Tracing.ApplicationInsights/RequestSpan.cs
+++ b/src/Petabridge.Tracing.ApplicationInsights/RequestSpan.cs
@@ -37,7 +37,16 @@ namespace Petabridge.Tracing.ApplicationInsights
         public override ISpan SetTag(string key, string value)
         {
             // guard the trace so we don't collect garbage
-            if (!Finished.HasValue) _operation.Telemetry.Properties[key] = value;
+            if (!Finished.HasValue)
+            {
+                _operation.Telemetry.Properties[key] = value;
+                
+                // need to flag this as an error in Application Insights
+                if (key.Equals(OpenTracing.Tag.Tags.Error.Key))
+                {
+                    _operation.Telemetry.Success = false;
+                }
+            }
 
             return this;
         }

--- a/src/common.props
+++ b/src/common.props
@@ -15,7 +15,7 @@ Updated to latest [Akka.NET version (1.4.11)](https://github.com/akkadotnet/akka
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
-    <TestSdkVersion>16.11.0</TestSdkVersion>
+    <TestSdkVersion>17.1.0</TestSdkVersion>
     <NBenchVersion>1.2.2</NBenchVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -15,7 +15,7 @@ Updated to latest [Akka.NET version (1.4.11)](https://github.com/akkadotnet/akka
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
-    <TestSdkVersion>16.8.0</TestSdkVersion>
+    <TestSdkVersion>16.9.4</TestSdkVersion>
     <NBenchVersion>1.2.2</NBenchVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -15,7 +15,7 @@ Updated to latest [Akka.NET version (1.4.11)](https://github.com/akkadotnet/akka
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
-    <TestSdkVersion>16.9.4</TestSdkVersion>
+    <TestSdkVersion>16.11.0</TestSdkVersion>
     <NBenchVersion>1.2.2</NBenchVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -2,10 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2020 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.2.1</VersionPrefix>
-    <PackageReleaseNotes>Updated to latest Application Insights driver (2.16.0)
-Updated to latest [Akka.NET version (1.4.11)](https://github.com/akkadotnet/akka.net/releases/tag/1.4.11)
-[Added constructor overload for passing in `IScopeManager` more easily](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/64)</PackageReleaseNotes>
+    <VersionPrefix>0.3.0</VersionPrefix>
+    <PackageReleaseNotes>Updated to latest Application Insights driver (2.20.0)
+[Resolved: Need to mark errors recorded in spans as errors in the Application Insights client](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/114)</PackageReleaseNotes>
     <PackageIconUrl>
     </PackageIconUrl>
     <PackageIconUrl>https://petabridge.com/images/logo.png</PackageIconUrl>


### PR DESCRIPTION
#### 0.3.0 March 18 2022 ####
* Updated to latest Application Insights driver (2.20.0)
* [Resolved: Need to mark errors recorded in spans as errors in the Application Insights client](https://github.com/petabridge/Petabridge.Tracing.ApplicationInsights/issues/114)